### PR TITLE
Comment PR: Cleanup for use in v2 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: php
 php:
     - 7.1
     - 7.2
+    - 7.3
 
 # test only master (+ Pull requests)
 branches:

--- a/DependencyInjection/EzSystemsCommentsExtension.php
+++ b/DependencyInjection/EzSystemsCommentsExtension.php
@@ -27,10 +27,6 @@ class EzSystemsCommentsExtension extends Extension
         $loader->load('services.yml');
         $loader->load('default_settings.yml');
 
-        if (class_exists('\\EzSystems\\EzPlatformAdminUi\\Tab\\AbstractTab')) {
-            $loader->load('services_v2.yml');
-        }
-
         $processor = new ConfigurationProcessor($container, 'ez_comments');
         $processor->mapConfig($config, new ConfigurationMapper());
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -56,3 +56,11 @@ services:
     ez_comments.controller.comments_renderer:
         class: '%ez_comments.controller.comments_renderer.class%'
         arguments: ['@ez_comments.renderer', '@ezpublish.api.service.content']
+
+    # eZ Platform Admin UI integrations
+    ez_comments.comments.tab:
+        class: EzSystems\CommentsBundle\Tab\CommentsTab
+        parent: EzSystems\EzPlatformAdminUi\Tab\AbstractTab
+        arguments: [ '@twig', '@translator', '@ez_comments.renderer', '@ezpublish.api.service.content' ]
+        tags:
+            - { name: ezplatform.tab, group: 'location-view' }

--- a/Resources/config/services_v2.yml
+++ b/Resources/config/services_v2.yml
@@ -1,7 +1,0 @@
-services:
-    ez_comments.comments.tab:
-        class: EzSystems\CommentsBundle\Tab\CommentsTab
-        parent: EzSystems\EzPlatformAdminUi\Tab\AbstractTab
-        arguments: [ '@twig', '@translator', '@ez_comments.renderer', '@ezpublish.api.service.content' ]
-        tags:
-            - { name: ezplatform.tab, group: 'location-view' }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ezsystems/comments-bundle",
-    "description": "Commenting system for eZ Publish",
+    "description": "Commenting system for eZ Platform",
     "license": "GPL-2.0",
     "type": "ezplatform-bundle",
     "authors": [
@@ -14,12 +14,14 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "~6.0@dev || ^7.0@dev"
+        "php": "^7.1",
+        "ezsystems/ezplatform-admin-ui": "^1.5",
+        "ezsystems/ezpublish-kernel": "^7.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7|^6.0",
+        "phpunit/phpunit": "^6.0|^7.0",
         "friendsofphp/php-cs-fixer": "~2.7.1",
-        "matthiasnoback/symfony-dependency-injection-test": "~1.0|~2.0"
+        "matthiasnoback/symfony-dependency-injection-test": "~3.0"
     },
     "suggest": {
         "ezsystems/ngsymfonytools-bundle": "Needed for use with legacy backend tab for administration of comments"
@@ -29,11 +31,16 @@
     },
     "target-dir": "EzSystems/CommentsBundle",
     "scripts": {
-        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating",
+        "test": "@php ./vendor/bin/phpunit"
+    },
+    "scripts-descriptions": {
+        "fix-cs": "Fix Coding standard issues in current checkout.",
+        "test": "Run all unit tests"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "6.2.x-dev"
+            "dev-master": "7.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ezsystems/ezpublish-kernel": "^7.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0|^7.0",
+        "phpunit/phpunit": "^7.5.16",
         "friendsofphp/php-cs-fixer": "~2.7.1",
         "matthiasnoback/symfony-dependency-injection-test": "~3.0"
     },


### PR DESCRIPTION
@dspe Suggestions for cleanup, missing afaik is simple test for the comment part as that should now be possible without trickery.

We'll also need to update cs fixer to be able top get it to work on PHP 7.3, but that should be separate PR.